### PR TITLE
updating aws-sns-lifecycle with IMDSv2

### DIFF
--- a/lib/utils/aws-sns-lifecycle.js
+++ b/lib/utils/aws-sns-lifecycle.js
@@ -11,6 +11,48 @@ const {LifeCycleEvents} = require('./constants');
 const express = require('express');
 const app = express();
 const getString = bent('string');
+
+// IMDSv2 token TTL in seconds (6 hours max)
+const IMDS_TOKEN_TTL = 21600;
+
+/**
+ * Get EC2 instance metadata using IMDSv2 (with fallback to IMDSv1)
+ * @param {string} path - The metadata path (e.g., 'instance-id', 'local-ipv4')
+ * @param {object} logger - Logger instance
+ * @returns {Promise<string>} - The metadata value
+ */
+async function getInstanceMetadata(path, logger) {
+  const metadataUrl = `http://169.254.169.254/latest/meta-data/${path}`;
+  
+  // Try IMDSv2 first (requires token)
+  try {
+    // Get session token for IMDSv2
+    const getToken = bent('PUT', 'string', {
+      'X-aws-ec2-metadata-token-ttl-seconds': String(IMDS_TOKEN_TTL)
+    });
+    const token = await getToken('http://169.254.169.254/latest/api/token');
+    
+    // Use token to get metadata
+    const getWithToken = bent('GET', 'string', {
+      'X-aws-ec2-metadata-token': token
+    });
+    const result = await getWithToken(metadataUrl);
+    logger.debug({path, result}, 'Retrieved metadata using IMDSv2');
+    return result;
+  } catch (imdsv2Error) {
+    logger.debug({err: imdsv2Error.message, path}, 'IMDSv2 failed, trying IMDSv1');
+    
+    // Fallback to IMDSv1 (no token required)
+    try {
+      const result = await getString(metadataUrl);
+      logger.debug({path, result}, 'Retrieved metadata using IMDSv1');
+      return result;
+    } catch (imdsv1Error) {
+      logger.error({err: imdsv1Error.message, path}, 'Both IMDSv1 and IMDSv2 failed');
+      throw imdsv1Error;
+    }
+  }
+}
 const {
   SNSClient,
   SubscribeCommand,
@@ -122,9 +164,33 @@ class SnsNotifier extends Emitter {
 
   async init() {
     try {
-      this.logger.info('SnsNotifier: retrieving instance data');
-      this.instanceId = await getString('http://169.254.169.254/latest/meta-data/instance-id');
-      this.publicIp = await getString('http://169.254.169.254/latest/meta-data/public-ipv4');
+      this.logger.info('SnsNotifier: retrieving instance data (IMDSv2 with IMDSv1 fallback)');
+      this.instanceId = await getInstanceMetadata('instance-id', this.logger);
+      
+      // Try to get public IP first, fall back to private IP if not available
+      try {
+        this.publicIp = await getInstanceMetadata('public-ipv4', this.logger);
+      } catch (err) {
+        this.logger.info({err: err.message}, 'Could not retrieve public IP, trying private IP');
+        this.publicIp = null;
+      }
+      
+      // If no public IP, use private IP
+      if (!this.publicIp || this.publicIp === '' || this.publicIp === 'undefined') {
+        try {
+          this.publicIp = await getInstanceMetadata('local-ipv4', this.logger);
+          this.logger.info({privateIp: this.publicIp}, 'Using private IP for SNS endpoint');
+        } catch (err) {
+          this.logger.error({err}, 'Could not retrieve private IP either');
+          throw new Error('Could not retrieve any IP address from EC2 metadata');
+        }
+      }
+      
+      // Validate we have a valid IP
+      if (!this.publicIp || this.publicIp === '' || this.publicIp === 'undefined') {
+        throw new Error('Invalid IP address retrieved from EC2 metadata');
+      }
+      
       this.logger.info({
         instanceId: this.instanceId,
         publicIp: this.publicIp
@@ -146,11 +212,20 @@ class SnsNotifier extends Emitter {
 
     } catch (err) {
       this.logger.error({err}, 'Error retrieving AWS instance metadata');
+      throw err; // Re-throw to prevent subscribe() from being called
     }
   }
 
   async subscribe() {
     try {
+      // Validate endpoint before subscribing
+      if (!this.snsEndpoint || this.snsEndpoint.includes('undefined') || this.snsEndpoint === 'http://:') {
+        throw new Error(`Invalid SNS endpoint: ${this.snsEndpoint}. Check EC2 metadata retrieval.`);
+      }
+      
+      this.logger.info({snsEndpoint: this.snsEndpoint, topicArn: AWS_SNS_TOPIC_ARN}, 
+        'Subscribing to SNS topic');
+      
       const params = {
         Protocol: 'http',
         TopicArn: AWS_SNS_TOPIC_ARN,
@@ -208,7 +283,14 @@ class SnsNotifier extends Emitter {
 
 module.exports = async function(logger) {
   const notifier = new SnsNotifier(logger);
-  await notifier.init();
+  
+  try {
+    await notifier.init();
+  } catch (err) {
+    logger.error({err}, 'Failed to initialize SNS notifier - lifecycle events will be disabled');
+    throw err;
+  }
+  
   await notifier.subscribe();
 
   process.on('SIGHUP', async() => {

--- a/lib/utils/sbc-pinger.js
+++ b/lib/utils/sbc-pinger.js
@@ -1,9 +1,9 @@
 const assert = require('assert');
 const crypto = require('crypto');
-const {LifeCycleEvents, FS_UUID_SET_NAME} = require('./constants');
+const { LifeCycleEvents, FS_UUID_SET_NAME } = require('./constants');
 const Emitter = require('events');
 const debug = require('debug')('jambonz:feature-server');
-const noopLogger = {info: () => {}, error: () => {}};
+const noopLogger = { info: () => { }, error: () => { } };
 const {
   JAMBONES_SBCS,
   K8S,
@@ -25,11 +25,11 @@ module.exports = (logger) => {
       .split(',')
       .map((sbc) => sbc.trim());
     assert.ok(sbcs.length, 'JAMBONES_SBCS env var is empty or misconfigured');
-    logger.info({sbcs}, 'SBC inventory');
+    logger.info({ sbcs }, 'SBC inventory');
   }
   else if (K8S && K8S_SBC_SIP_SERVICE_NAME) {
     sbcs = [`${K8S_SBC_SIP_SERVICE_NAME}:5060`];
-    logger.info({sbcs}, 'SBC inventory');
+    logger.info({ sbcs }, 'SBC inventory');
   }
 
   // listen for SNS lifecycle changes
@@ -37,28 +37,28 @@ module.exports = (logger) => {
   let dryUpCalls = false;
   if (AWS_SNS_TOPIC_ARN && AWS_REGION) {
 
-    (async function() {
+    (async function () {
       try {
         lifecycleEmitter = await require('./aws-sns-lifecycle')(logger);
 
         lifecycleEmitter
-          .on('SubscriptionConfirmation', ({publicIp}) => {
-            const {srf} = require('../..');
+          .on('SubscriptionConfirmation', ({ publicIp }) => {
+            const { srf } = require('../..');
             srf.locals.publicIp = publicIp;
           })
-          .on(LifeCycleEvents.ScaleIn, async() => {
+          .on(LifeCycleEvents.ScaleIn, async () => {
             logger.info('AWS scale-in notification: begin drying up calls');
             dryUpCalls = true;
             lifecycleEmitter.operationalState = LifeCycleEvents.ScaleIn;
 
-            const {srf} = require('../..');
-            const {writeSystemAlerts} = srf.locals;
+            const { srf } = require('../..');
+            const { writeSystemAlerts } = srf.locals;
             if (writeSystemAlerts) {
-              const {SystemState, FEATURE_SERVER} = require('./constants');
+              const { SystemState, FEATURE_SERVER } = require('./constants');
               await writeSystemAlerts({
                 system_component: FEATURE_SERVER,
-                state : SystemState.GracefulShutdownInProgress,
-                fields : {
+                state: SystemState.GracefulShutdownInProgress,
+                fields: {
                   detail: `feature-server with process_id ${process.pid} shutdown in progress`,
                   host: srf.locals?.ipv4
                 }
@@ -80,25 +80,58 @@ module.exports = (logger) => {
           })
           .on(LifeCycleEvents.StandbyEnter, () => {
             dryUpCalls = true;
-            const {srf} = require('../..');
+            const { srf } = require('../..');
             pingProxies(srf);
 
             logger.info('AWS enter pending state notification: begin drying up calls');
           })
           .on(LifeCycleEvents.StandbyExit, () => {
             dryUpCalls = false;
-            const {srf} = require('../..');
+            const { srf } = require('../..');
             pingProxies(srf);
 
             logger.info('AWS enter pending state notification: re-enable calls');
           });
       } catch (err) {
-        logger.error({err}, 'Failure creating SNS notifier, lifecycle events will be disabled');
+        logger.error({ err }, 'Failure creating SNS notifier, lifecycle events will be disabled');
       }
     })();
   }
   else if (K8S) {
     lifecycleEmitter.scaleIn = () => process.exit(0);
+  }
+  else {
+    process.on('SIGUSR1', () => {
+      logger.info('received SIGUSR1: begin drying up calls for scale-in');
+      dryUpCalls = true;
+
+      const { srf } = require('../..');
+      const { writeSystemAlerts } = srf.locals;
+      if (writeSystemAlerts) {
+        const { SystemState, FEATURE_SERVER } = require('./constants');
+        writeSystemAlerts({
+          system_component: FEATURE_SERVER,
+          state: SystemState.GracefulShutdownInProgress,
+          fields: {
+            detail: `feature-server with process_id ${process.pid} shutdown in progress`,
+            host: srf.locals?.ipv4
+          }
+        });
+      }
+      pingProxies(srf);
+
+      // if we have zero calls, we can complete the scale-in right
+      setTimeout(() => {
+        const calls = srf.locals.sessionTracker.count;
+        if (calls === 0) {
+          logger.info('scale-in can complete immediately as we have no calls in progress');
+          process.exit(0);
+        }
+        else {
+          logger.info(`${calls} calls in progress; scale-in will complete when they are done`);
+        }
+      }, 5000);
+    });
   }
 
 
@@ -128,33 +161,33 @@ module.exports = (logger) => {
   if (K8S) {
     setImmediate(() => {
       logger.info('disabling OPTIONS pings since we are running as a kubernetes service');
-      const {srf} = require('../..');
-      const {addToSet} = srf.locals.dbHelpers;
+      const { srf } = require('../..');
+      const { addToSet } = srf.locals.dbHelpers;
       const uuid = srf.locals.fsUUID = crypto.randomUUID();
 
       /* in case redis is restarted, re-insert our key every so often */
       setInterval(() => {
         // eslint-disable-next-line max-len
-        addToSet(FS_UUID_SET_NAME, uuid).catch((err) => logger.info({err}, `Error adding ${uuid} to set ${FS_UUID_SET_NAME}`));
+        addToSet(FS_UUID_SET_NAME, uuid).catch((err) => logger.info({ err }, `Error adding ${uuid} to set ${FS_UUID_SET_NAME}`));
       }, 30000);
       // eslint-disable-next-line max-len
-      addToSet(FS_UUID_SET_NAME, uuid).catch((err) => logger.info({err}, `Error adding ${uuid} to set ${FS_UUID_SET_NAME}`));
+      addToSet(FS_UUID_SET_NAME, uuid).catch((err) => logger.info({ err }, `Error adding ${uuid} to set ${FS_UUID_SET_NAME}`));
     });
   }
   else {
     // OPTIONS ping the SBCs from each feature server every 60 seconds
     setInterval(() => {
-      const {srf} = require('../..');
+      const { srf } = require('../..');
       pingProxies(srf);
     }, OPTIONS_PING_INTERVAL);
 
     // initial ping once we are up
-    setTimeout(async() => {
+    setTimeout(async () => {
 
       // if SBCs are auto-scaling, monitor them as they come and go
-      const {srf} = require('../..');
+      const { srf } = require('../..');
       if (!JAMBONES_SBCS) {
-        const {monitorSet} = srf.locals.dbHelpers;
+        const { monitorSet } = srf.locals.dbHelpers;
         const setName = `${(JAMBONES_CLUSTER_ID || 'default')}:active-sip`;
         await monitorSet(setName, 10, (members) => {
           sbcs = members;


### PR DESCRIPTION
Refactor EC2 metadata retrieval to use IMDSv2 with fallback to IMDSv1. Update instance initialization to handle public and private IP retrieval more robustly.